### PR TITLE
Fix reshuffle face-down state

### DIFF
--- a/lib/CaboGame.dart
+++ b/lib/CaboGame.dart
@@ -97,8 +97,14 @@ class CaboGame {
 
   PlayingCard drawCard() {
     if (deck.isEmpty && discardPile.isNotEmpty) {
-      // Reshuffle discard pile except top card if deck is empty
+      // Reshuffle discard pile except the top card if deck is empty
       PlayingCard top = discardPile.removeLast();
+
+      // Turn the rest of the discard pile face down before shuffling
+      for (var card in discardPile) {
+        card.isFaceUp = false;
+      }
+
       deck.addAll(discardPile);
       discardPile = [top];
       deck.shuffle(Random());

--- a/test/cabo_game_test.dart
+++ b/test/cabo_game_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cabo_offline/CaboGame.dart';
+import 'package:cabo_offline/PlayingCard.dart';
+
+void main() {
+  test('reshuffled discard cards are turned face down', () {
+    final game = CaboGame();
+
+    // Empty the deck to trigger reshuffle
+    game.deck.clear();
+    // Create a discard pile with two face-up cards
+    game.discardPile = [
+      PlayingCard(value: 5, suit: 'Hearts', isFaceUp: true),
+      PlayingCard(value: 7, suit: 'Spades', isFaceUp: true),
+    ];
+    game.topDiscard = game.discardPile.last;
+
+    // Draw a card to force deck reshuffle from discard pile
+    final card = game.drawCard();
+
+    // The drawn card should have been turned face down before drawing
+    expect(card.isFaceUp, isFalse);
+    // Remaining cards in deck should also be face down
+    expect(game.deck.every((c) => c.isFaceUp == false), isTrue);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,16 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:cabo_offline/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('App builds', (WidgetTester tester) async {
+    // Build the app and trigger a frame.
+    await tester.pumpWidget(const CaboApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the title is shown.
+    expect(find.text('Cabo Card Game'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Turn discarded cards face down before reshuffling into the deck
- Adjust widget test to use `CaboApp`
- Add unit test ensuring reshuffled cards are face down

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895bdd04aa0832b8112e31ba9f553a5